### PR TITLE
Button manger !  need for the narrow screens  was not room on the N4

### DIFF
--- a/source/PackageDisplay.js
+++ b/source/PackageDisplay.js
@@ -261,10 +261,6 @@ enyo.kind({
         this.$.PackageFeed.setContent(this.currentPackage.feedString);
 
 		this.buttonManger();
-     //   this.$.InstallButton.setDisabled(this.currentPackage.isInstalled);
-    //   this.$.UpdateButton.setDisabled(!this.currentPackage.isInstalled || !this.currentPackage.hasUpdate);
-     //   this.$.RemoveButton.setDisabled(!this.currentPackage.isInstalled);
-     //   this.$.LaunchButton.setDisabled(!this.currentPackage.isInstalled);
     },
     
     buttonManger: function() {
@@ -283,6 +279,5 @@ enyo.kind({
     	if(this.currentPackage.hasUpdate){
     		this.$.UpdateButton.show();
     	}
-    
     }
 });


### PR DESCRIPTION
Add a button manger to hide button if package is installed or not

this fix is for the narrow screen (phones) like the N4

Open-WebOS-DCO-1.0-Signed-Off-By: john mcconnell  johnmcconnell@yahoo.com
