### PR TITLE
Re-implementation of manage feeds dialog

### DIFF
--- a/source/App.css
+++ b/source/App.css
@@ -146,6 +146,14 @@
 	border-radius: 0 0 8px 8px;
 }
 
+.webosstyle-list-swipable-groupbox-item-first {
+	border-radius: 8px 8px 0 0;
+}
+
+.webosstyle-list-swipable-groupbox-item-last {
+	border-radius: 0 0 8px 8px;
+}
+
 .webosstyle-list-groupbox-item-content {
 	border-color: #aaaaaa;
 	border-style: solid; 

--- a/source/ManageFeedsDialog.js
+++ b/source/ManageFeedsDialog.js
@@ -22,7 +22,7 @@ enyo.kind({
 			]}
 		],
 		swipeableComponents: [
-			{style: "height: 100%; margin-left: 5px; margin-right: 5px; background-color: darkgrey; text-align:center", components: [
+			{name: "swipableFeed", style: "height: 100%; margin-left: 5px; margin-right: 5px; background-color: darkgrey; text-align:center", components: [
 				{name: "swipeableDeleteButton", kind: "onyx.Button", style: "margin-top: 10px; margin-right: 10px;", classes:"onyx-negative", ontap: "deleteButtonTapped", content: $L("Delete")},
 				{name: "swipeableCancelButton", kind: "onyx.Button", style: "margin-left: 10px;", ontap: "cancelButtonTapped", content: $L("Cancel")}
 			]}
@@ -102,6 +102,22 @@ enyo.kind({
         // because setting it on the list itself fails:
         this.$.ManageFeedsList.setPersistSwipeableItem(true);
         this.activeItem = inEvent.index;
+        
+   		this.$.swipableFeed.addRemoveClass("webosstyle-list-swipable-groupbox-item-first", inEvent.index == 0);
+		this.$.swipableFeed.addRemoveClass("webosstyle-list-swipable-groupbox-item-last", inEvent.index == (this.feeds.length - 1));
+		
+		//This chunk is required because the height is applied to the row as a style, so we have to override the style
+		//Can't just use a class.
+		if (inEvent.index == (this.feeds.length - 1))
+		{ 
+			if (!this.rowHeight)
+			{
+				var currentRowHeight = this.$.swipableFeed.getComputedStyleValue("height");
+				this.rowHeight = currentRowHeight.substring(0, currentRowHeight.length - 2);
+			}
+			this.$.swipableFeed.applyStyle("height", (this.rowHeight - 5) + "px");
+		}
+		
         this.swiping = true;
     },
 


### PR DESCRIPTION
I wound up re-implementing the manage feeds dialog using an AroundList instead of a DataRepeater and collections.
The reason for doing this is that DataRepeater does not support swipable at this point, so I needed to use an AroundList to implement swipe to delete functionality.

As a side effect, the new feed section is now at the top of the dialog. This is because aroundlist only supports content above the list. It looks like there is initial support for content below the list, but the list currently just renders over top of this content. 
