### PR TITLE
Deploy webos-lib as well

### DIFF
--- a/deploy.json
+++ b/deploy.json
@@ -2,5 +2,5 @@
 	"enyo": "./enyo",
 	"packagejs": "./package.js",
 	"assets": ["./icon.png", "./index.html", "./assets", "./appinfo.json", "framework_config.json"],
-	"libs": ["./lib/onyx", "./lib/layout"]
+	"libs": ["./lib/onyx", "./lib/layout", "./lib/webos-lib"]
 }


### PR DESCRIPTION
This does not make a lot of difference, but the PortsSearch in
the banner gets its icon back at least. Can't hurt.