### PR TITLE
Handle install params with launch request

### DIFF
--- a/build-and-deploy.sh
+++ b/build-and-deploy.sh
@@ -1,8 +1,31 @@
 #!/bin/bash
 
-
+#build
 node enyo/tools/deploy.js -o deploy/org.webosports.app.preware
 
-adb push deploy/org.webosports.app.preware /usr/palm/applications/org.webosports.app.preware
-adb shell systemctl restart luna-next
-adb forward tcp:1122 tcp:1122
+#figure out how to deploy
+DEVICE=1
+adb get-state 1>/dev/null 2>&1 && devfound=true || devfound=false
+if [ "$devfound" = "false" ]; then
+    echo "lune-install: no devices found via adb, assuming emulator"
+    DEVICE=0
+fi
+
+# launchCommand="/usr/bin/luna-send -n 10 -f luna://com.palm.applicationManager/open '{ \"id\": \"org.webosports.app.preware\", \"params\": { \"type\": \"install\", \"file\":\"http:\/\/packages.webosarchive.com/AppPackages/com.jonandnic.enyo.webbtracker_1.0.1_all.ipk\" } }'"
+launchCommand="/usr/bin/luna-send -n 10 -f luna://com.palm.applicationManager/open '{ \"id\": \"org.webosports.app.preware\", \"params\": { } }'"
+if [ $DEVICE -eq 1 ]; then
+    #deploy for connected device
+    adb push deploy/org.webosports.app.preware /usr/palm/applications/org.webosports.app.preware
+    adb shell restart luna-next
+    sleep 15
+    adb shell $launchCommand
+    adb forward tcp:1122 tcp:1122
+    exit
+else
+    #deploy for emulator
+    scp -r -P 5522 deploy/org.webosports.app.preware root@localhost:/usr/palm/applications/
+    ssh root@localhost -p 5522 restart luna-next
+    sleep 5
+    ssh root@localhost -p 5522 $launchCommand
+    exit
+fi

--- a/source/App.js
+++ b/source/App.js
@@ -12,7 +12,8 @@ enyo.kind({
             onbackbutton: "handleBackGesture",
             onCoreNaviDragStart: "handleCoreNaviDragStart",
             onCoreNaviDrag: "handleCoreNaviDrag",
-            onCoreNaviDragFinish: "handleCoreNaviDragFinish"
+            onCoreNaviDragFinish: "handleCoreNaviDragFinish",
+            onLaunchedWithInstallRequest: "handleLaunchInstallRequest"
         },
         {name: "AppPanels", kind: "AppPanels"},
         {kind: "CoreNavi", fingerTracking: true},
@@ -51,6 +52,11 @@ enyo.kind({
     },
     reloadPackageList: function (inSender, inEvent) {
         this.$.AppPanels.doReloadList();
+    },
+    handleLaunchInstallRequest: function (inSender, inEvent) {
+        //enyo.info("Handling launch with install request on: " + this.name + " for " + inEvent.params);
+        this.showInstallPackageDialog();
+        this.$.InstallPackageDialog.doInstall(inEvent.params);
     },
     showSettingsDialog: function (inSender, inEvent) {
         this.$.SettingsDialog.updateValues();

--- a/source/AppPanels.js
+++ b/source/AppPanels.js
@@ -38,7 +38,7 @@ enyo.kind({
             components: [
                 {
                     kind: "PortsSearch",
-                    title: "Preware",
+                    title: "Preware 2",
                     taglines: [
                         "I live... again...",
                         "Miss me?",
@@ -206,7 +206,14 @@ enyo.kind({
     handleDeviceReady: function (inSender, inEvent) {
         if (!this.fired) {
             this.fired = true;
-            UpdateFeeds.startUpdateFeeds();
+            UpdateFeeds.startUpdateFeeds();            
+
+            //This appears to be our first opportunity to evaluate launch parameters, but they must be handled on the owner
+            var launchParams = JSON.parse(PalmSystem.launchParams);
+            if (launchParams && launchParams.type && launchParams.type.toLowerCase() == "install" && launchParams.file) {
+                enyo.warn("Preware was launched with a request to install an app: " + launchParams.file);
+                enyo.Signals.send("onLaunchedWithInstallRequest", { params: launchParams.file });
+            }
         }
     },
     handleBackGesture: function (inSender, inEvent) {

--- a/source/InstallPackageDialog.js
+++ b/source/InstallPackageDialog.js
@@ -194,6 +194,11 @@ enyo.kind({
     create: function (inSender, inEvent) {
         this.inherited(arguments);
     },
+    doInstall: function (installUrl) {
+        enyo.warn("In InstallPackageDialog: " + installUrl);
+        this.$.ipkEdit.setValue(installUrl);
+        this.validatePackageLocation();
+    },
     //handlers
     handleBackGesture: function (inSender, inEvent) {
         if (!this.getShowing() || this.$.filePickerPanel.getShowing()) {


### PR DESCRIPTION
Addresses Issue 10 here: https://github.com/webOS-ports/luneos-testing/issues/10
These changes allow another app to launch Preware with a request to install another app. This is crucial for App Museum II to work. Everything works except that Preware is still trying to call the old installer service.
