### PR TITLE
packageModel.js: Show app name that's being uninstalled

### DIFF
--- a/source/model/packageModel.js
+++ b/source/model/packageModel.js
@@ -1157,7 +1157,7 @@ enyo.kind({
                     enyo.Signals.send("onPackageRefresh");
 
                     // message
-                    msg = this.type + $L(" removed");
+                    msg = this.title + $L(" removed");
 
                     // do finishing stuff
                     if (this.hasFlags('remove')) {


### PR DESCRIPTION
Seems like a typo in the original code, causing the app name to show up as "Unknown".

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>