### PR TITLE
preware: Drop public/private and legacy registration

### DIFF
--- a/oe-service/src/luna_methods.c
+++ b/oe-service/src/luna_methods.c
@@ -2432,7 +2432,7 @@ bool impersonate_method(LSHandle* lshandle, LSMessage *message, void *ctx) {
 
   char *paramstring = NULL;
   paramstring = json_object_to_json_string(params);
-  if (!LSCallFromApplication(priv_serviceHandle, uri, paramstring, json_object_get_string(id),
+  if (!LSCallFromApplication(serviceHandle, uri, paramstring, json_object_get_string(id),
 			     impersonate_handler, message, NULL, &lserror)) goto error;
 
   return true;
@@ -2467,7 +2467,7 @@ bool listApps_method(LSHandle* lshandle, LSMessage *message, void *ctx) {
   LSError lserror;
   LSErrorInit(&lserror);
   LSMessageRef(message);
-  retVal = LSCall(priv_serviceHandle, "luna://com.palm.applicationManager/listApps", "{}",
+  retVal = LSCall(serviceHandle, "luna://com.palm.applicationManager/listApps", "{}",
 		  listApps_handler, message, NULL, &lserror);
   if (!retVal) {
     LSErrorPrint(&lserror, stderr);
@@ -2501,7 +2501,7 @@ bool installStatus_method(LSHandle* lshandle, LSMessage *message, void *ctx) {
   LSError lserror;
   LSErrorInit(&lserror);
   LSMessageRef(message);
-  retVal = LSCall(priv_serviceHandle, "luna://com.webos.appInstallService/status", "{}",
+  retVal = LSCall(serviceHandle, "luna://com.webos.appInstallService/status", "{}",
 		  installStatus_handler, message, NULL, &lserror);
   if (!retVal) {
     LSErrorPrint(&lserror, stderr);
@@ -2537,7 +2537,7 @@ bool addResource_method(LSHandle* lshandle, LSMessage *message, void *ctx) {
   LSMessageRef(message);
   const char *payload;
   payload = LSMessageGetPayload(message);
-  retVal = LSCall(priv_serviceHandle, "luna://com.palm.applicationManager/addResourceHandler",
+  retVal = LSCall(serviceHandle, "luna://com.palm.applicationManager/addResourceHandler",
 		  payload, addResource_handler, message, NULL, &lserror);
   if (!retVal) {
     LSErrorPrint(&lserror, stderr);
@@ -2573,7 +2573,7 @@ bool swapResource_method(LSHandle* lshandle, LSMessage *message, void *ctx) {
   LSMessageRef(message);
   const char *payload;
   payload = LSMessageGetPayload(message);
-  retVal = LSCall(priv_serviceHandle, "luna://com.palm.applicationManager/swapResourceHandler",
+  retVal = LSCall(serviceHandle, "luna://com.palm.applicationManager/swapResourceHandler",
 		  payload, swapResource_handler, message, NULL, &lserror);
   if (!retVal) {
     LSErrorPrint(&lserror, stderr);
@@ -2636,8 +2636,8 @@ LSMethod luna_methods[] = {
   { 0, 0 }
 };
 
-bool register_methods(LSPalmService *serviceHandle, LSError lserror) {
+bool register_methods(LSHandle *serviceHandle, LSError lserror) {
   strcpy(device, "webOS"); strcpy(token, "konami");
-  return LSPalmServiceRegisterCategory(serviceHandle, "/", luna_methods,
-				       NULL, NULL, NULL, &lserror);
+  return LSRegisterCategory(serviceHandle, "/", luna_methods,
+				       NULL, NULL, &lserror);
 }

--- a/oe-service/src/luna_methods.h
+++ b/oe-service/src/luna_methods.h
@@ -22,7 +22,7 @@
 
 #include <lunaservice.h>
 
-bool register_methods(LSPalmService *serviceHandle, LSError lserror);
+bool register_methods(LSHandle *serviceHandle, LSError lserror);
 
 // Twice the chunk size (so any character can be escaped), plus a terminating null.
 #define MAXBUFLEN 8193

--- a/oe-service/src/luna_service.c
+++ b/oe-service/src/luna_service.c
@@ -36,16 +36,14 @@ bool luna_service_initialize(const char *dbusAddress) {
   if (loop==NULL)
     goto end;
 
-  returnVal = LSRegisterPalmService(dbusAddress, &serviceHandle, &lserror);
-  if (returnVal) {
-    pub_serviceHandle = LSPalmServiceGetPublicConnection(serviceHandle);
-    priv_serviceHandle = LSPalmServiceGetPrivateConnection(serviceHandle);
-  } else
+  returnVal = LSRegister(dbusAddress, &serviceHandle, &lserror);
+  if (!returnVal) {
     goto end;
+  }
 
-  returnVal =  register_methods(serviceHandle, lserror);
+  returnVal = register_methods(serviceHandle, lserror);
   if (returnVal) {
-    LSGmainAttachPalmService(serviceHandle, loop, &lserror);
+    LSGmainAttach(serviceHandle, loop, &lserror);
   }
 
  end:

--- a/oe-service/src/luna_service.h
+++ b/oe-service/src/luna_service.h
@@ -24,9 +24,7 @@
 
 #include <lunaservice.h>
 
-LSPalmService	*serviceHandle;
-LSHandle	*pub_serviceHandle;
-LSHandle	*priv_serviceHandle;
+LSHandle	*serviceHandle;
 
 bool luna_service_initialize(const char *);
 void luna_service_start(void);


### PR DESCRIPTION
Since this no longer works with latest luna-service2 from OSE.

Fixes:
/mnt/5ba5d474-0b2d-49d6-a5a6-9de20c3ac967/kirkstone-qt6/webos-ports/tmp-glibc/work/core2-64-webos-linux/org.webosports.service.ipkg/2.0.0-2+gitAUTOINC+1fe4a701f2-r0/git/oe-service/src/luna_service.h:27:1: error: unknown type name 'LSPalmService'
   27 | LSPalmService   *serviceHandle;
      | ^~~~~~~~~~~~~
In file included from /mnt/5ba5d474-0b2d-49d6-a5a6-9de20c3ac967/kirkstone-qt6/webos-ports/tmp-glibc/work/core2-64-webos-linux/org.webosports.service.ipkg/2.0.0-2+gitAUTOINC+1fe4a701f2-r0/git/oe-service/src/ipkgservice.h:23,
                 from /mnt/5ba5d474-0b2d-49d6-a5a6-9de20c3ac967/kirkstone-qt6/webos-ports/tmp-glibc/work/core2-64-webos-linux/org.webosports.service.ipkg/2.0.0-2+gitAUTOINC+1fe4a701f2-r0/git/oe-service/src/ipkgservice.c:23:
/mnt/5ba5d474-0b2d-49d6-a5a6-9de20c3ac967/kirkstone-qt6/webos-ports/tmp-glibc/work/core2-64-webos-linux/org.webosports.service.ipkg/2.0.0-2+gitAUTOINC+1fe4a701f2-r0/git/oe-service/src/luna_methods.h:25:23: error: unknown type name 'LSPalmService'
   25 | bool register_methods(LSPalmService *serviceHandle, LSError lserror);
      |                       ^~~~~~~~~~~~~

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>