### PR TITLE
org.webosports.service.ipkg.perm.json: Fix service name

### DIFF
--- a/oe-service/files/sysbus/org.webosports.service.ipkg.perm.json
+++ b/oe-service/files/sysbus/org.webosports.service.ipkg.perm.json
@@ -3,7 +3,7 @@
         "application.launcher",
         "networkconnection.management",
         "networkconnection.query",
-        "opkg-service.operation",
+        "ipkg-service.operation",
         "wifi.management",
         "wifi.query"
     ]


### PR DESCRIPTION
Fixes:

WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: 'opkg-service.operation' being used in:
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   org.webosports.service.ipkg.perm.json