### PR TITLE
Remove the workaround to include lunaservice.h

### DIFF
--- a/oe-service/src/luna_methods.h
+++ b/oe-service/src/luna_methods.h
@@ -20,7 +20,7 @@
 #ifndef LUNA_METHODS_H_
 #define LUNA_METHODS_H_
 
-#include <lunaservice.h>
+#include <luna-service2/lunaservice.h>
 
 bool register_methods(LSHandle *serviceHandle, LSError lserror);
 

--- a/oe-service/src/luna_service.h
+++ b/oe-service/src/luna_service.h
@@ -22,7 +22,7 @@
 
 #include <stdbool.h>
 
-#include <lunaservice.h>
+#include <luna-service2/lunaservice.h>
 
 LSHandle	*serviceHandle;
 


### PR DESCRIPTION
Use luna-service2/lunaservice.h instead.

Signed-off-by: Herman van Hazendonk github.com@herrie.org