### PR TITLE
packagesModel.js: Work around incorrect deviceVersion

### DIFF
--- a/source/model/packagesModel.js
+++ b/source/model/packagesModel.js
@@ -291,7 +291,7 @@ enyo.singleton({
                 this.deviceVersion = device.version;
             }
         }
-        if (!this.deviceVersion || this.deviceVersion === "0.0.0") {
+        if (!this.deviceVersion || this.deviceVersion === "0.0.0" || this.deviceVersion === "00.00.00") {
             console.log("Work around luna-next issue. Setting version to 3.0.5, had version: " + this.deviceVersion);
             this.deviceVersion = "3.0.5";
         }


### PR DESCRIPTION
Seems that nowadays WAM returns 00.00.00 instead of 0.0.0 so we need to make sure that we cover that case too.

Works around: https://github.com/webOS-ports/luneos-testing/issues/34