### PR TITLE
Fix missing return values

### DIFF
--- a/oe-service/src/luna_methods.c
+++ b/oe-service/src/luna_methods.c
@@ -809,7 +809,7 @@ void *update_thread(void *arg) {
 
  end:
   LSMessageUnref(message);
-  return;
+  return NULL;
 
  error:
   LSErrorPrint(&lserror, stderr);
@@ -1529,7 +1529,7 @@ void *feed_download_thread(void *arg) {
 
  end:
   LSMessageUnref(message);
-  return;
+  return NULL;
  error:
   LSErrorPrint(&lserror, stderr);
   LSErrorFree(&lserror);
@@ -1926,7 +1926,7 @@ void *appinstaller_install_thread(void *arg) {
 
  end:
   LSMessageUnref(message);
-  return;
+  return NULL;
  error:
   LSErrorPrint(&lserror, stderr);
   LSErrorFree(&lserror);
@@ -2003,7 +2003,7 @@ void *opkg_install_thread(void *arg) {
 
  end:
   LSMessageUnref(message);
-  return;
+  return NULL;
  error:
   LSErrorPrint(&lserror, stderr);
   LSErrorFree(&lserror);
@@ -2054,7 +2054,7 @@ void *remove_thread(void *arg) {
 
  end:
   LSMessageUnref(message);
-  return;
+  return NULL;
  error:
   LSErrorPrint(&lserror, stderr);
   LSErrorFree(&lserror);
@@ -2134,7 +2134,7 @@ void *opkg_replace_thread(void *arg) {
 
  end:
   LSMessageUnref(message);
-  return;
+  return NULL;
  error:
   LSErrorPrint(&lserror, stderr);
   LSErrorFree(&lserror);
@@ -2214,7 +2214,7 @@ void *appinstaller_replace_thread(void *arg) {
 
  end:
   LSMessageUnref(message);
-  return;
+  return NULL;
  error:
   LSErrorPrint(&lserror, stderr);
   LSErrorFree(&lserror);


### PR DESCRIPTION
* return false for error conditions
* fixes return-mismatch issues which are fatal by default with gcc-14

oe-service/src/luna_methods.c:812:3: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]
oe-service/src/luna_methods.c:1532:3: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]
oe-service/src/luna_methods.c:1929:3: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]
oe-service/src/luna_methods.c:2006:3: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]
oe-service/src/luna_methods.c:2057:3: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]
oe-service/src/luna_methods.c:2137:3: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]
oe-service/src/luna_methods.c:2217:3: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]